### PR TITLE
feat: GCS Presigned URL 발급 및 업로드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### secret yml ###
 /src/main/resources/secret.yml
+/src/main/resources/*.json

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	implementation(platform("com.google.cloud:libraries-bom:26.60.0"))
+	implementation("com.google.cloud:google-cloud-storage")
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -4,6 +4,8 @@ availableSecrets:
       env: SECRET_ENV_LOCAL
     - versionName: projects/782806232816/secrets/APPLICATION-REMOTE/versions/latest
       env: SECRET_ENV_REMOTE
+    - versionName: projects/782806232816/secrets/GCS-KEY/versions/latest
+      env: SECRET_ENV_KEY
 
 steps:
   # 🔹 1. LOCAL 서비스용 secret 파일 생성 + 빌드 + 배포
@@ -13,7 +15,8 @@ steps:
       - '-c'
       - |
         echo "$$SECRET_ENV_LOCAL" > src/main/resources/secret.yml
-    secretEnv: ['SECRET_ENV_LOCAL']
+        echo "$$SECRET_ENV_KEY" > src/main/resources/custhumb.json
+    secretEnv: ['SECRET_ENV_LOCAL','SECRET_ENV_KEY']
 
   - name: gradle:8.5-jdk21
     args: [ 'gradle','build' ]
@@ -44,7 +47,8 @@ steps:
       - '-c'
       - |
         echo "$$SECRET_ENV_REMOTE" > src/main/resources/secret.yml
-    secretEnv: ['SECRET_ENV_REMOTE']
+        echo "$$SECRET_ENV_KEY" > src/main/resources/custhumb.json
+    secretEnv: [ 'SECRET_ENV_REMOTE','SECRET_ENV_KEY' ]
 
   - name: gradle:8.5-jdk21
     args: [ 'gradle','build' ]

--- a/src/main/java/com/zolp/custhumb/domain/thema/api/ThemaApi.java
+++ b/src/main/java/com/zolp/custhumb/domain/thema/api/ThemaApi.java
@@ -5,6 +5,7 @@ import com.zolp.custhumb.domain.thema.dto.request.ThemaRequest;
 import com.zolp.custhumb.domain.thema.dto.response.ThemaResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/themas")
+@SecurityRequirement(name = "accessToken")
 @Tag(name = "테마 API", description = "사용자 테마 등록 및 조회 API")
 public class ThemaApi {
     private final ThemaService themaService;

--- a/src/main/java/com/zolp/custhumb/domain/thumbnail/api/ThumbnailApi.java
+++ b/src/main/java/com/zolp/custhumb/domain/thumbnail/api/ThumbnailApi.java
@@ -6,6 +6,7 @@ import com.zolp.custhumb.domain.thumbnail.dto.request.EditThumbnailRequest;
 import com.zolp.custhumb.domain.thumbnail.dto.response.ThumbnailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/thumbnails")
+@SecurityRequirement(name = "accessToken")
 @Tag(name = "썸네일 API", description = "썸네일 생성 및 편집 API")
 public class ThumbnailApi {
     private final ThumbnailService thumbnailService;

--- a/src/main/java/com/zolp/custhumb/domain/upload/api/UploadApi.java
+++ b/src/main/java/com/zolp/custhumb/domain/upload/api/UploadApi.java
@@ -1,5 +1,6 @@
 package com.zolp.custhumb.domain.upload.api;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/upload")
+@SecurityRequirement(name = "accessToken")
 @Tag(name = "업로드 API", description = "GCP Presigned URL 발급 API")
 public class UploadApi {
     //private final VideoService videoService;

--- a/src/main/java/com/zolp/custhumb/domain/upload/api/UploadApi.java
+++ b/src/main/java/com/zolp/custhumb/domain/upload/api/UploadApi.java
@@ -1,12 +1,13 @@
 package com.zolp.custhumb.domain.upload.api;
 
+import com.zolp.custhumb.infra.domain.gcs.GcsSignedUrlService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URL;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,17 +15,20 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "accessToken")
 @Tag(name = "업로드 API", description = "GCP Presigned URL 발급 API")
 public class UploadApi {
-    //private final VideoService videoService;
+
+    private final GcsSignedUrlService gcsSignedUrlService;
+
+    private static final String BUCKET_NAME = "custhumb-bucket"; // 🔁 실제 GCS 버킷 이름으로 교체
 
     @GetMapping("/video")
-    public ResponseEntity<String> getVideoPresignedUrl() {
-        String url = "";
-        return ResponseEntity.ok(url);
+    public ResponseEntity<String> getVideoPresignedUrl(@RequestParam String fileName) {
+        URL url = gcsSignedUrlService.generateUploadUrl(BUCKET_NAME, fileName, "video/mp4", 15);
+        return ResponseEntity.ok(url.toString());
     }
 
     @GetMapping("/image")
-    public ResponseEntity<String> getImagePresignedUrl() {
-        String url = "";
-        return ResponseEntity.ok(url);
+    public ResponseEntity<String> getImagePresignedUrl(@RequestParam String fileName) {
+        URL url = gcsSignedUrlService.generateUploadUrl(BUCKET_NAME, fileName, "image/png", 5);
+        return ResponseEntity.ok(url.toString());
     }
 }

--- a/src/main/java/com/zolp/custhumb/global/config/SecurityConfig.java
+++ b/src/main/java/com/zolp/custhumb/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests((registry) ->
                         registry
-                                .requestMatchers("/api/**","/oauth/**").permitAll()
+                                .requestMatchers("/api/auth/**","/oauth/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**", "/webjars/**","/index.html").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/zolp/custhumb/global/config/SwaggerConfig.java
+++ b/src/main/java/com/zolp/custhumb/global/config/SwaggerConfig.java
@@ -1,6 +1,8 @@
 package com.zolp.custhumb.global.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -9,14 +11,18 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
-
 @OpenAPIDefinition(
         servers = {
                 @Server(url = "https://planpal-server-remote-772190012442.asia-northeast3.run.app", description = "리모트 서버"),
-                @Server(url = "https://planpal-server-local-772190012442.asia-northeast3.run.app", description = "로컬 서버")
+                @Server(url = "34.64.57.161", description = "로컬 서버")
         })
 @Configuration
+@SecurityScheme(
+        name = "accessToken",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
 @RequiredArgsConstructor
 public class SwaggerConfig {
 

--- a/src/main/java/com/zolp/custhumb/infra/domain/gcs/GcsSignedUrlService.java
+++ b/src/main/java/com/zolp/custhumb/infra/domain/gcs/GcsSignedUrlService.java
@@ -1,0 +1,44 @@
+package com.zolp.custhumb.infra.domain.gcs;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class GcsSignedUrlService {
+
+    private final Storage storage;
+
+    public GcsSignedUrlService(@Value("${gcp.credentials.path}") Resource keyFile) throws IOException {
+        this.storage = StorageOptions.newBuilder()
+                .setCredentials(ServiceAccountCredentials.fromStream(keyFile.getInputStream()))
+                .build()
+                .getService();
+    }
+
+    public URL generateUploadUrl(String bucketName, String objectName, String contentType, int expireMinutes) {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName))
+                .setContentType(contentType)
+                .build();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", contentType);
+
+        return storage.signUrl(
+                blobInfo,
+                expireMinutes,
+                TimeUnit.MINUTES,
+                Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+                Storage.SignUrlOption.withExtHeaders(headers),
+                Storage.SignUrlOption.withV4Signature()
+        );
+    }
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -2,51 +2,84 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Spring Security 권한 관리</title>
+    <title>Presigned URL 테스트</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
 </head>
 <body>
 <div class="container">
-    <h1>Spring Security 권한 관리</h1>
+    <h1>Google OAuth 로그인</h1>
     <button id="google-login" class="btn btn-primary">Google 로그인</button>
+
+    <hr>
+
+    <h2>📤 Presigned URL 테스트</h2>
+
+    <div class="form-group">
+        <label>파일 선택 (Video)</label>
+        <input type="file" id="videoFile" accept="video/*" class="form-control">
+        <button id="uploadVideoBtn" class="btn btn-success">영상 업로드</button>
+    </div>
+
+    <div class="form-group">
+        <label>파일 선택 (Image)</label>
+        <input type="file" id="imageFile" accept="image/*" class="form-control">
+        <button id="uploadImageBtn" class="btn btn-success">이미지 업로드</button>
+    </div>
 </div>
 
 <script>
     $('#google-login').click(function () {
         const clientId = '782806232816-4n74niupirb3c6cdarr0gthv2ulnp059.apps.googleusercontent.com';
         const redirectUri = encodeURIComponent('http://localhost:8080/oauth/google/callback');
-        const responseType = 'code';
         const scope = encodeURIComponent('openid profile email');
-
-        const authUrl = `https://accounts.google.com/o/oauth2/auth?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&scope=${scope}`;
-
+        const authUrl = `https://accounts.google.com/o/oauth2/auth?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}`;
         window.location.href = authUrl;
     });
-</script>
 
-<script>
-    $(document).ready(function () {
-        if (window.location.pathname === '/oauth/google/callback') {
-            const params = new URLSearchParams(window.location.search);
-            const code = params.get('code');
-
-            if (code) {
-                // code를 다시 백엔드 POST로 전달
-                $.ajax({
-                    url: '/api/auth/google',
-                    type: 'POST',
-                    contentType: 'application/json',
-                    data: JSON.stringify({ authorizationCode: code  }),
-                    success: function (response) {
-                        alert('로그인 성공: ' + JSON.stringify(response));
-                    },
-                    error: function (xhr, status, error) {
-                        alert('로그인 실패: ' + xhr.responseText);
-                    }
-                });
-            }
+    function uploadFile(api, file, contentType) {
+        if (!file) {
+            alert("파일을 선택하세요.");
+            return;
         }
+
+        const fileName = encodeURIComponent(file.name);
+
+        $.ajax({
+            url: `/api/upload/${api}?fileName=${fileName}`,
+            type: 'GET',
+            success: function (presignedUrl) {
+                fetch(presignedUrl, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': contentType
+                    },
+                    body: file
+                }).then(response => {
+                    if (response.ok) {
+                        alert(`${api} 업로드 성공`);
+                    } else {
+                        alert(`${api} 업로드 실패: ` + response.statusText);
+                    }
+                }).catch(error => {
+                    console.error(error);
+                    alert("업로드 중 오류 발생");
+                });
+            },
+            error: function () {
+                alert("Presigned URL 발급 실패");
+            }
+        });
+    }
+
+    $('#uploadVideoBtn').click(() => {
+        const file = document.getElementById('videoFile').files[0];
+        uploadFile('video', file, 'video/mp4');
+    });
+
+    $('#uploadImageBtn').click(() => {
+        const file = document.getElementById('imageFile').files[0];
+        uploadFile('image', file, 'image/png');
     });
 </script>
 </body>


### PR DESCRIPTION
## 주요 변경 사항
- GCS 버킷에 업로드할 수 있도록 Presigned URL 발급 기능 구현
  - gcs key 기반 인증
  - `/api/upload/video` (video/mp4) 5분 제한
  - `/api/upload/image` (image/png) 15분 제한
- 프론트에서 Presigned URL을 이용해 파일 업로드하는 HTML 테스트 페이지 작성
- GCS CORS 설정 적용 (cors.json 설정 및 반영)
- 로컬 테스트를 위한 http vm instance(컨테이너 전용 OS) 생성